### PR TITLE
Remove branch protection for egit-website repo

### DIFF
--- a/otterdog/eclipse-egit.jsonnet
+++ b/otterdog/eclipse-egit.jsonnet
@@ -112,16 +112,6 @@ orgs.newOrg('eclipse-egit') {
     orgs.newRepo('egit-website') {
       allow_merge_commit: true,
       allow_update_branch: false,
-      "branch_protection_rules": [
-        {
-          "allows_force_pushes": true,
-          "pattern": "*",
-          "push_restrictions": [
-            "@eclipse-egit-bot"
-          ],
-          "restricts_pushes": true
-        }
-      ],
       default_branch: "master",
       delete_branch_on_merge: false,
       secret_scanning: "disabled",


### PR DESCRIPTION
We missed to import this repo into GerritHub. To import it I need push permissions. After it's imported into GerritHub I will restore the branch protection.