### PR TITLE
Revert "Remove branch protection for egit-website repo (#4)"

### DIFF
--- a/otterdog/eclipse-egit.jsonnet
+++ b/otterdog/eclipse-egit.jsonnet
@@ -112,6 +112,16 @@ orgs.newOrg('eclipse-egit') {
     orgs.newRepo('egit-website') {
       allow_merge_commit: true,
       allow_update_branch: false,
+      "branch_protection_rules": [
+        {
+          "allows_force_pushes": true,
+          "pattern": "*",
+          "push_restrictions": [
+            "@eclipse-egit-bot"
+          ],
+          "restricts_pushes": true
+        }
+      ],
       default_branch: "master",
       delete_branch_on_merge: false,
       secret_scanning: "disabled",


### PR DESCRIPTION
This reverts commit 42447c2089708554cfa852c7ad6fa48757d5a00c.

We successfully imported the egit-website repo into GerritHub hence we can re-establish the branch protection.